### PR TITLE
Add CentOS 10 OS support

### DIFF
--- a/images/guest-centos-10/mkosi.conf
+++ b/images/guest-centos-10/mkosi.conf
@@ -1,0 +1,9 @@
+[Include]
+Include=../../modules/guest
+
+[Distribution]
+Distribution=centos
+Release=10
+
+[Content]
+Packages=kernel,kernel-modules-core,systemd,systemd-boot-unsigned,systemd-udev,NetworkManager,systemd-journal-remote,bind-utils,jq,python3,rpm

--- a/images/host-centos-10/mkosi.conf
+++ b/images/host-centos-10/mkosi.conf
@@ -1,0 +1,16 @@
+[Include]
+# Host Components
+Include=../../modules/host
+# Build and integrate snphost
+Include=../../modules/snphost-build
+# Build and integrate snpguest
+Include=../../modules/snpguest-build
+# Build and integrate fpaste
+Include=../../modules/fpaste-build
+
+[Distribution]
+Distribution=centos
+Release=10
+
+[Content]
+Packages=kernel,libselinux,systemd,systemd-boot-unsigned,systemd-udev,NetworkManager,edk2-ovmf,qemu-kvm-core,dnf,systemd-journal-remote,net-tools,openssh-server,xxd,python3,python3-pip,jq

--- a/images/host-centos-10/mkosi.postinst
+++ b/images/host-centos-10/mkosi.postinst
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eux
+
+# Crete the qemu-system-x86_64 executable from the CentOS's qemu binary.
+mkosi-chroot \
+	cp /usr/libexec/qemu-kvm /usr/bin/qemu-system-x86_64
+
+# Install emoji module using pip
+mkosi-chroot \
+	pip3 install  emoji
+

--- a/modules/launch-snp-guest/mkosi.extra/usr/local/lib/scripts/launch-guest.sh
+++ b/modules/launch-snp-guest/mkosi.extra/usr/local/lib/scripts/launch-guest.sh
@@ -29,6 +29,7 @@ truncate -s 0 ${GUEST_ERROR_LOG}
 # Launch the SNP guest in background
 exec qemu-system-x86_64 \
   -enable-kvm \
+  -machine q35 \
   -cpu EPYC-v4 \
   -machine memory-encryption=sev0 \
   -monitor none \

--- a/modules/logging/display-guest-environment/mkosi.extra/usr/local/lib/scripts/sev_v_2_0_0_0/guest_environment.py
+++ b/modules/logging/display-guest-environment/mkosi.extra/usr/local/lib/scripts/sev_v_2_0_0_0/guest_environment.py
@@ -26,6 +26,7 @@ class GuestEnvironment:
 # Get installed guest package versions
     def get_guest_kernel_version(self):
         os_id = self.get_guest_os_id()
+        os_id = os_id.replace('"','')
         kernel_pkg_name = GuestOSPackage.guest_kernel.get(os_id)
         kernel_command = subprocess.run(["/usr/local/lib/scripts/sev_v_2_0_0_0/package_version.sh", kernel_pkg_name], capture_output=True, text=True, check=True)
         guest_kernel_version = kernel_command.stdout.strip()

--- a/modules/logging/display-guest-environment/mkosi.extra/usr/local/lib/scripts/sev_v_2_0_0_0/guest_os_package.py
+++ b/modules/logging/display-guest-environment/mkosi.extra/usr/local/lib/scripts/sev_v_2_0_0_0/guest_os_package.py
@@ -9,3 +9,4 @@ class GuestOSPackage:
     guest_kernel["fedora"]="kernel"
     guest_kernel["ubuntu"]="linux-image-virtual"
     guest_kernel["debian"]="linux-image-amd64"
+    guest_kernel["centos"]="kernel"

--- a/modules/logging/display-guest-environment/mkosi.extra/usr/local/lib/scripts/sev_v_2_0_0_0/package_version.sh
+++ b/modules/logging/display-guest-environment/mkosi.extra/usr/local/lib/scripts/sev_v_2_0_0_0/package_version.sh
@@ -13,7 +13,7 @@ fi
 package="$1"
 
 declare -A package_managers
-package_managers=( ["fedora"]="rpm" ["ubuntu"]="apt" ["debian"]="apt")
+package_managers=( ["fedora"]="rpm" ["ubuntu"]="apt" ["debian"]="apt" ["centos"]="rpm")
 
 os_name=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')
 os_package_manager=${package_managers[${os_name}]}

--- a/modules/logging/generate-sev-report/mkosi.extra/usr/local/lib/scripts/sev_report/test_environment/sev_version_2_0_0_0/host_environment/host_environment.py
+++ b/modules/logging/generate-sev-report/mkosi.extra/usr/local/lib/scripts/sev_report/test_environment/sev_version_2_0_0_0/host_environment/host_environment.py
@@ -33,6 +33,7 @@ class HostEnvironment:
         os_version_command = os_version_command.strip()
         command = subprocess.run(os_version_command, shell=True, check=True, text=True, capture_output=True)
         host_os_id = command.stdout.strip()
+        host_os_id = host_os_id.replace('"','')
         return host_os_id
 
     # Get installed host package versions

--- a/modules/logging/generate-sev-report/mkosi.extra/usr/local/lib/scripts/sev_report/test_environment/sev_version_2_0_0_0/host_environment/host_os_package.py
+++ b/modules/logging/generate-sev-report/mkosi.extra/usr/local/lib/scripts/sev_report/test_environment/sev_version_2_0_0_0/host_environment/host_os_package.py
@@ -9,13 +9,16 @@ class HostOSPackage:
     qemu["fedora"]="qemu"
     qemu["ubuntu"]="qemu-system"
     qemu["debian"]="qemu-system"
+    qemu["centos"]="qemu-kvm-core"
 
     ovmf={}
     ovmf["fedora"]="edk2-ovmf"
     ovmf["ubuntu"]="ovmf"
     ovmf["debian"]="ovmf"
+    ovmf["centos"]="edk2-ovmf"
 
     host_kernel={}
     host_kernel["fedora"]="kernel"
     host_kernel["ubuntu"]="linux-image-virtual"
     host_kernel["debian"]="linux-image-amd64"
+    host_kernel["centos"]="kernel"

--- a/modules/logging/generate-sev-report/mkosi.extra/usr/local/lib/scripts/sev_report/test_environment/sev_version_2_0_0_0/host_environment/package_version.sh
+++ b/modules/logging/generate-sev-report/mkosi.extra/usr/local/lib/scripts/sev_report/test_environment/sev_version_2_0_0_0/host_environment/package_version.sh
@@ -13,7 +13,7 @@ fi
 package="$1"
 
 declare -A package_managers
-package_managers=( ["fedora"]="rpm" ["ubuntu"]="apt" ["debian"]="apt" )
+package_managers=( ["fedora"]="rpm" ["ubuntu"]="apt" ["debian"]="apt" ["centos"]="rpm" )
 
 os_name=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')
 os_package_manager=${package_managers[${os_name}]}

--- a/modules/snpguest/mkosi.build
+++ b/modules/snpguest/mkosi.build
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eux
+
+mkdir -p ${DESTDIR}/etc/modules-load.d/
+
+# Load MSR module
+touch ${DESTDIR}/etc/modules-load.d/msr.conf
+echo "msr" > ${DESTDIR}/etc/modules-load.d/msr.conf
+
+# Load sev-guest module
+touch ${DESTDIR}/etc/modules-load.d/sev-guest.conf
+echo "sev-guest" > ${DESTDIR}/etc/modules-load.d/sev-guest.conf

--- a/modules/snphost/mkosi.build
+++ b/modules/snphost/mkosi.build
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eux
+
+mkdir -p ${DESTDIR}/etc/modules-load.d/
+
+# Load MSR module
+touch ${DESTDIR}/etc/modules-load.d/msr.conf
+echo "msr" > ${DESTDIR}/etc/modules-load.d/msr.conf
+


### PR DESCRIPTION
- Added new Centos 10 host and gust OS image configuration.
- Added mkosi postinstruction script to create qemu-system-x86_64 executable to use this binary instead of qemu-kvm binary, and install emoji module on the host.
- Loads MSR and sev-guest kernel modules in the mkosi.build scripts under snphost and snpguest modules.
- Refactored snpguest-attestation.sh to add DNS resolution check for KDS domain before fetching ARK/ASK certificates.
- Added Centos 10 host packages (QEMU, OVMF, host kernel package), Centos 10 guest package(guest kernel package), Centos 10 package manager support to fetch Centos 10 package version support