### PR TITLE
fix: Restructure to get the service description for host/guest

### DIFF
--- a/modules/logging/sev-certificate-generator/mkosi.extra/usr/local/lib/scripts/generate_sev_certificate/service/service.py
+++ b/modules/logging/sev-certificate-generator/mkosi.extra/usr/local/lib/scripts/generate_sev_certificate/service/service.py
@@ -24,10 +24,16 @@ class Service:
 
     def get_service_description(self, service, platform):
         """Get the SNP host/guest test service description."""
-
-        service_message = self.get_service_message(service, platform)
         description_line_keyterm = "starting"
-        service_description_command = f"echo \"{service_message}\" | grep -i \"{description_line_keyterm}\" | head -1"
+        match platform:
+            case "host" :
+                host_service_description = f"journalctl -o cat | grep -i {description_line_keyterm} | grep -i {service} | head -1"
+                service_description_command = host_service_description
+
+            case "guest" :
+                guest_service_description = f"journalctl -D {self.guest_logs_path} -o cat | grep -i {description_line_keyterm} | grep -i {service} | head -1"
+                service_description_command = guest_service_description
+
         command = subprocess.run(service_description_command, shell=True, check=True, text=True, capture_output=True)
 
         # Receive "<service name>-<service description>" text from the command output
@@ -36,7 +42,6 @@ class Service:
         # Parse the <service description> part
         match = re.split(r'(?i)-\s+', service_detail, maxsplit=1)
         service_description=match[1].strip()
-
         return service_description
 
     def extract_service_status(self, service, platform):


### PR DESCRIPTION
Restructured service description to get host/guest service description from the entire journalctl logs